### PR TITLE
fix: package extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 [extensions]
 JLD2Ext = "JLD2"
 JuMPExt = ["JuMP", "GLPK"]
-MakieExt = "Makie"
+MakieExt = ["Makie", "NetworkLayout", "CairoMakie", "GraphMakie", "GLMakie", "WGLMakie", "GraphPlot"]
 
 [compat]
 AutoHashEquals = "2.1.0"

--- a/ext/JLD2Ext/JLD2Ext.jl
+++ b/ext/JLD2Ext/JLD2Ext.jl
@@ -1,6 +1,14 @@
 module JLD2Ext
 
-using CodingTheory, JLD2
+import CodingTheory
+
+import CodingTheory: TriangularColorCode488, TriangularColorCode666, PlanarSurfaceCode3D, PlanarSurfaceCode3D_X, ToricCode3D, StabilizerCode, set_logicals!, Oscar
+
+import JLD2
+
+import JLD2: @load
+
+import Oscar: GF, matrix
 
 include("Quantum/misc_known_codes.jl")
 

--- a/ext/JLD2Ext/JLD2Ext.jl
+++ b/ext/JLD2Ext/JLD2Ext.jl
@@ -2,7 +2,7 @@ module JLD2Ext
 
 import CodingTheory
 
-import CodingTheory: TriangularColorCode488, TriangularColorCode666, PlanarSurfaceCode3D, PlanarSurfaceCode3D_X, ToricCode3D, StabilizerCode, set_logicals!, Oscar
+import CodingTheory: TriangularColorCode488, TriangularColorCode666, PlanarSurfaceCode3D, PlanarSurfaceCode3D_X, ToricCode3D, StabilizerCode, set_logicals!
 
 import JLD2
 

--- a/ext/JuMPExt/JuMPExt.jl
+++ b/ext/JuMPExt/JuMPExt.jl
@@ -1,6 +1,16 @@
 module JuMPExt
 
-using CodingTheory, JuMP, GLPK
+import CodingTheory
+
+import CodingTheory: optimal_lambda, optimal_rho, optimal_lambda_and_rho, LP_decoder_LDPC, AbstractLinearCode, BinarySymmetricChannel
+
+import JuMP
+
+import JuMP: @variable, @constraint, @objective
+
+import GLPK
+
+import Oscar
 
 include("LDPC/decoders.jl")
 include("LDPC/analysis.jl")

--- a/ext/MakieExt/MakieExt.jl
+++ b/ext/MakieExt/MakieExt.jl
@@ -2,7 +2,7 @@ module MakieExt
 
 import CodingTheory
 
-import CodingTheory:Tanner_graph_plot, weight_plot, EXIT_chart_plot, degree_distributions_plot, count_short_cycles_plot, count_elementary_cycles_plot, ACE_spectrum_plot, computation_graph, weight_plot_CSS_X, weight_plot_CSS_Z, weight_plot_CSS
+import CodingTheory: Tanner_graph_plot, weight_plot, EXIT_chart_plot, degree_distributions_plot, count_short_cycles_plot, count_elementary_cycles_plot, ACE_spectrum_plot, computation_graph, weight_plot_CSS_X, weight_plot_CSS_Z, weight_plot_CSS
 
 import Makie
 

--- a/ext/MakieExt/MakieExt.jl
+++ b/ext/MakieExt/MakieExt.jl
@@ -1,6 +1,25 @@
 module MakieExt
 
-using CodingTheory, Makie, NetworkLayout, CairoMakie, GraphMakie, GLMakie, WGLMakie, GraphPlot, Graphs
+import CodingTheory
+
+import CodingTheory:Tanner_graph_plot, weight_plot, EXIT_chart_plot, degree_distributions_plot, count_short_cycles_plot, count_elementary_cycles_plot, ACE_spectrum_plot, computation_graph, weight_plot_CSS_X, weight_plot_CSS_Z, weight_plot_CSS
+
+import Makie
+
+import NetworkLayout
+
+import CairoMakie
+
+import GraphMakie
+
+import GLMakie
+
+import WGLMakie
+
+import GraphPlot
+
+import Oscar
+
 import Graphs as Grphs
 # import CairoMakie: save
 

--- a/src/Quantum/misc_known_codes.jl
+++ b/src/Quantum/misc_known_codes.jl
@@ -1339,8 +1339,8 @@ function ToricCode(d::Int)
         X2[1, c] = F_one
     end
     set_logicals!(S, vcat(X1, Z1, X2, Z2))
-    set_dressed_X_minimum_distance!(S, d)
-    set_dressed_Z_minimum_distance!(S, d)
+    set_X_minimum_distance!(S, d)
+    set_Z_minimum_distance!(S, d)
     return S
 end
 

--- a/test/Quantum/misc_known_codes_test.jl
+++ b/test/Quantum/misc_known_codes_test.jl
@@ -1,5 +1,6 @@
 @testset "Quantum/misc_known_codes.jl" begin
     using JLD2
+    using CodingTheory
 
     S = Q9143()
     @test S.n == 9


### PR DESCRIPTION
This PR fixes the three  Package Extensions namely, `JuMPExt`, `JLD2Ext`, `MakieExt`. The first two have been successfully compiled as well. The `WGLMakie` takes forever to compile, so couldn't really test `MakieExt` by drawing `weight_plots`. 
 
As instructed, I tested the `"src/Quantum/misc_known_codes_test.jl"`. This contains many codes that uses `JLD2Ext.` All the tests passed. 

```julia
julia> include("misc_known_codes_test.jl")
Precompiling JLD2Ext
        Info Given JLD2Ext was explicitly requested, output will be shown live 
WARNING: could not import CodingTheory.PlanarSurfaceCode3D into JLD2Ext
WARNING: could not import CodingTheory.ToricCode3D into JLD2Ext
  1 dependency successfully precompiled in 23 seconds. 180 already precompiled.
  1 dependency had output during precompilation:
┌ CodingTheory → JLD2Ext
│  [Output was shown above]                                                                                                    
└                                                                                                                              
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
Test Summary:               | Pass  Total     Time
Quantum/misc_known_codes.jl |  130    130  1m15.3s
Test.DefaultTestSet("Quantum/misc_known_codes.jl", Any[], 130, false, false, true, 1.726006162109859e9, 1.726006237412491e9, false, "/home/Transcendence/Desktop/ct/task/CodingTheory/test/Quantum/misc_known_codes_test.jl")
```

There was a minor bug in the `ToricCode` that was detected by the tests.  1 test failed. It was that `set_dressed_X_minimum_distance!` seems to be for `subsystem` codes, but since Toric code is a Stabilizer code, so we have to use `set_X_minimum_distance!`. 

```julia
julia> include("misc_known_codes_test.jl")
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
┌ Warning: The distance set is greater than the current upper bound of 2
└ @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/stabilizer_code.jl:556
Quantum/misc_known_codes.jl: Error During Test at /home/Desktop/ct/task/CodingTheory/test/Quantum/misc_known_codes_test.jl:1
  Got exception outside of a @test
  Only valid for subsytem codes; use `set_X_minimum_distance!` for stabilizer codes.
  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:35
    [2] set_dressed_X_minimum_distance!(::HasNoGauges, ::CodingTheory.IsCSS, S::StabilizerCodeCSS, d::Int64)
      @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/subsystem_code.jl:1303
    [3] set_dressed_X_minimum_distance!(S::StabilizerCodeCSS, d::Int64)
      @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/subsystem_code.jl:1276
    [4] ToricCode(d::Int64)
      @ CodingTheory ~/Desktop/ct/task/CodingTheory/src/Quantum/misc_known_codes.jl:1342
    [5] macro expansion
      @ ~/Desktop/ct/task/CodingTheory/test/Quantum/misc_known_codes_test.jl:258 [inlined]
    [6] macro expansion
      @ ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
    [7] top-level scope
      @ ~/Desktop/ct/task/CodingTheory/test/Quantum/misc_known_codes_test.jl:2
    [8] include(fname::String)
      @ Base.MainInclude ./client.jl:489
    [9] top-level scope
      @ REPL[2]:1
   [10] eval
      @ ./boot.jl:385 [inlined]
   [11] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
      @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:150
   [12] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
      @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:246
   [13] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
      @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:231
   [14] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
      @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:389
   [15] run_repl(repl::REPL.AbstractREPL, consumer::Any)
      @ REPL ~/.julia/juliaup/julia-1.10.4+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:375
   [16] (::Base.var"#1013#1015"{Bool, Bool, Bool})(REPL::Module)
      @ Base ./client.jl:432
   [17] #invokelatest#2
      @ ./essentials.jl:892 [inlined]
   [18] invokelatest
      @ ./essentials.jl:889 [inlined]
   [19] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
      @ Base ./client.jl:416
   [20] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:333
   [21] _start()
      @ Base ./client.jl:552
Test Summary:               | Pass  Error  Total  Time
Quantum/misc_known_codes.jl |  118      1    119  8.6s
ERROR: LoadError: Some tests did not pass: 118 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /home/Transcendence/Desktop/ct/task/CodingTheory/test/Quantum/misc_known_codes_test.jl:1
```


This small change fixed the above mentioned error:
```
    set_X_minimum_distance!(S, d)
    set_Z_minimum_distance!(S, d)
```

