### PR TITLE
pretty mat

### DIFF
--- a/src/Classical/linear_code.jl
+++ b/src/Classical/linear_code.jl
@@ -583,7 +583,8 @@ function show(io::IO, C::AbstractLinearCode)
                 G = generator_matrix(C)
                 nr, nc = size(G)
                 println(io, "Generator matrix: $nr × $nc")
-                println(io, "\t" * replace(repr(MIME("text/plain"), G), r"\n" => "\n\t"))
+                println(io, "\t" * replace(replace(replace(repr(MIME("text/plain"), G), 
+                r"\n" => "\n\t"), r"\[" => ""), r"\]" => ""))
             end
         end
         # if !ismissing(C.weight_enum)

--- a/src/Classical/linear_code.jl
+++ b/src/Classical/linear_code.jl
@@ -583,18 +583,7 @@ function show(io::IO, C::AbstractLinearCode)
                 G = generator_matrix(C)
                 nr, nc = size(G)
                 println(io, "Generator matrix: $nr × $nc")
-                for i in 1:nr
-                    print(io, "\t")
-                    for j in 1:nc
-                        if j != nc
-                            print(io, "$(G[i, j]) ")
-                        elseif j == nc && i != nr
-                            println(io, "$(G[i, j])")
-                        else
-                            print(io, "$(G[i, j])")
-                        end
-                    end
-                end
+                println(io, "\t" * replace(repr(MIME("text/plain"), G), r"\n" => "\n\t"))
             end
         end
         # if !ismissing(C.weight_enum)


### PR DESCRIPTION
for printing generator matrices of linear codes use Oscars detailed printing with removed brackets.  

Looks like this:
![image](https://github.com/user-attachments/assets/36c6bc9c-cf48-4d4f-bc93-916951fe4c8c)
